### PR TITLE
JAWS Support

### DIFF
--- a/core/core-windows.py
+++ b/core/core-windows.py
@@ -126,7 +126,11 @@ class UserActions:
 
     def toggle_reader():
         """Toggles the screen reader on and off"""
-        actions.user.toggle_nvda()
+        screenreader: str = settings.get("user.screenreader_type")
+        if screenreader == "NVDA":
+            actions.user.toggle_nvda()
+        elif screenreader == "JAWS":
+            actions.user.toggle_jaws()
 
     def switch_voice():
         """Switches the voice for the screen reader"""

--- a/core/settings.py
+++ b/core/settings.py
@@ -62,6 +62,13 @@ mod.setting(
 )
 
 mod.setting(
+    "jaws_key",
+    type=str,
+    default="insert",
+    desc="The key that is used as the JAWS key",
+)
+
+mod.setting(
     "speak_errors",
     type=bool,
     default=True,

--- a/jaws/debug-jaws.talon
+++ b/jaws/debug-jaws.talon
@@ -1,0 +1,4 @@
+os: windows
+-
+
+key(ctrl-shift-alt-g): user.test_jaws_api()

--- a/jaws/jaws.py
+++ b/jaws/jaws.py
@@ -1,43 +1,8 @@
-# from __future__ import absolute_import
-# import pywintypes
-
+import ctypes
 import os
-
-from talon import Context, Module, actions, cron
-
-# class Jaws():
-#     """Supports the Jaws for Windows screen reader."""
-
-#     name = "jaws"
-
-#     def __init__(self, *args, **kwargs):
-#         super(Jaws, self).__init__(*args, **kwargs)
-#         try:
-#             self.object = load_com("FreedomSci.JawsApi", "jfwapi")
-#         except (pywintypes.com_error, TypeError):
-#             raise OutputError
-
-#     def braille(self, text, **options):
-#         # HACK: replace " with ', Jaws doesn't seem to understand escaping them with \
-#         text = text.replace('"', "'")
-#         self.object.RunFunction('BrailleString("%s")' % text)
-
-#     def speak(self, text, interrupt=False):
-#         self.object.SayString("      %s" % text, interrupt)
-
-#     def is_active(self):
-#         try:
-#             import win32gui
-#         except ImportError:
-#             return False
-#         try:
-#             return (
-#                 self.object.SayString("", 0) == True
-#                 or win32gui.FindWindow("JFWUI2", "JAWS") != 0
-#             )
-#         except:
-#             return False
-
+import time
+import subprocess
+from talon import Context, Module, actions, cron, speech_system, settings, scope, clip
 
 mod = Module()
 ctx = Context()
@@ -48,7 +13,6 @@ mod.tag("jaws_running", desc="If set, JAWS is running")
 @mod.scope
 def set_jaws_running_tag():
     """Update tags based on if JAWS is running"""
-    # TODO edge case on startup this might not be set yet
     try:
         ctx.tags = ["user.jaws_running"] if actions.user.is_jaws_running() else []
     except Exception:
@@ -56,6 +20,13 @@ def set_jaws_running_tag():
 
 
 if os.name == "nt":
+    # Load the JAWS COM object for speech synthesis
+    try:
+        import win32com.client
+        jaws = win32com.client.Dispatch("FreedomSci.JawsApi")
+    except Exception as e:
+        jaws = None
+
     cron.interval("3s", set_jaws_running_tag.update)
 
 
@@ -63,15 +34,119 @@ if os.name == "nt":
 class Actions:
     def toggle_jaws():
         """Toggles JAWS on and off"""
+        if not actions.user.is_jaws_running():
+            actions.key("ctrl-alt-j")
+            actions.user.tts("Turning JAWS on using shortcut control+alt+j")
+        else:
+            actions.user.tts("Turning JAWS off")
+            time.sleep(1)
+            actions.user.with_jaws_mod_press("j")
+            time.sleep(0.5)
+            actions.key("x")
 
     def restart_jaws():
         """Restarts JAWS"""
+        if actions.user.is_jaws_running():
+            actions.user.with_jaws_mod_press("control-f4")
+
+    def with_jaws_mod_press(keys: str):
+        """Presses the JAWS modifier key in combonation with provided keys. A cama sepparated list of keys can be provided for actions that require holding the jaws modifier while pressing keys more than once."""
+        key_list = keys.split(",")
+        jaws_key = settings.get("user.jaws_key")
+        actions.key(f"{jaws_key}:down")
+        try:
+            for key in key_list:
+                # actions.sleep("10ms")
+                actions.key(key.strip())
+            actions.sleep("10ms")
+        finally:
+            actions.key(f"{jaws_key}:up")
+
+    def with_jaws_mod_layered_key_presses(keys: str):
+        """Presses the JAWS modifier key in combonation with the first provided keys in the list. A cama sepparated list of keys to be pressed without the jaws modifier can be provided, for layered keyboard commands."""
+        key_list = keys.split(",")
+        jaws_keystroke = key_list.pop(0).strip()
+        jaws_key = settings.get("user.jaws_key")
+        actions.key(f"{jaws_key}:down")
+        try:
+            actions.sleep("50ms")
+            actions.key(jaws_keystroke)
+            actions.sleep("10ms")
+            actions.key(f"{jaws_key}:up")
+
+            for key in key_list:
+                actions.sleep("100ms")
+            actions.key(key.strip())
+        finally:
+            actions.key(f"{jaws_key}:up")
 
     def is_jaws_running() -> bool:
         """Returns true if JAWS is running"""
+        if os.name != "nt" or jaws is None:
+            return False
+
+        try:
+            # Test if JAWS is running by invoking a function from the API
+            return jaws.SayString("", False)  # If JAWS is running, this should not throw an error
+        except Exception:
+            return False
 
     def jaws_tts(text: str, use_clipboard: bool = False):
         """text to speech with JAWS"""
+
+    def test_jaws_api():
+        """Test the JAWS API connection"""
+        if jaws:
+            jaws.SayString("Testing JAWS integration.", False)
+        else:
+            actions.user.tts("Failed to connect to JAWS API.")
+
+
+ctxWindowsJAWSRunning = Context()
+ctxWindowsJAWSRunning.matches = r"""
+os: windows
+tag: user.jaws_running
+"""
+
+
+@ctxWindowsJAWSRunning.action_class("user")
+class UserActions:
+    def jaws_tts(text: str, use_clipboard: bool = False):
+        """text to speech with JAWS"""
+        if not jaws:
+            errorMessage = str(ctypes.WinError(1))
+            raise Exception(f"Error communicating between Talon and JAWS: {errorMessage}", e)
+
+        if use_clipboard:
+            with clip.revert():
+                clip.set_text(text)  # sets the result to the clipboard
+                actions.sleep("50ms")
+                actions.user.with_jaws_mod_press("super-x")
+        else:
+            jaws.SayString(text, False)
+
+    def tts(text: str, interrupt: bool = True):
+        """Text to speech within JAWS"""
+        if settings.get("user.tts_via_screenreader"):
+            cron.after("300ms", lambda: actions.user.jaws_tts(text))
+        else:
+            actions.user.base_win_tts(text, interrupt)
+
+    def cancel_current_speaker():
+        """Cancel JAWS speech"""
+        if jaws:
+            jaws.StopSpeech()
+
+    def braille(text: str):
+        """Output braille with JAWS"""
+        if jaws:
+            # HACK: replace " with ', Jaws doesn't seem to understand escaping them with \
+            text = text.replace('"', "'")
+            jaws.RunFunction(f'BrailleString("{text}")')
+
+    def switch_voice():
+        """Switches the voice for the screen reader"""
+        actions.user.tts("You must switch voice in JAWS manually")
 
 
 ctxWindowsJAWSRunning = Context()

--- a/jaws/jaws.py
+++ b/jaws/jaws.py
@@ -1,8 +1,9 @@
 import ctypes
 import os
-import time
 import subprocess
-from talon import Context, Module, actions, cron, speech_system, settings, scope, clip
+import time
+
+from talon import Context, Module, actions, clip, cron, scope, settings, speech_system
 
 mod = Module()
 ctx = Context()
@@ -23,6 +24,7 @@ if os.name == "nt":
     # Load the JAWS COM object for speech synthesis
     try:
         import win32com.client
+
         jaws = win32com.client.Dispatch("FreedomSci.JawsApi")
     except Exception as e:
         jaws = None
@@ -87,7 +89,9 @@ class Actions:
 
         try:
             # Test if JAWS is running by invoking a function from the API
-            return jaws.SayString("", False)  # If JAWS is running, this should not throw an error
+            return jaws.SayString(
+                "", False
+            )  # If JAWS is running, this should not throw an error
         except Exception:
             return False
 
@@ -115,7 +119,9 @@ class UserActions:
         """text to speech with JAWS"""
         if not jaws:
             errorMessage = str(ctypes.WinError(1))
-            raise Exception(f"Error communicating between Talon and JAWS: {errorMessage}", e)
+            raise Exception(
+                f"Error communicating between Talon and JAWS: {errorMessage}", e
+            )
 
         if use_clipboard:
             with clip.revert():

--- a/jaws/jaws.talon
+++ b/jaws/jaws.talon
@@ -16,7 +16,7 @@ next paragraph: key(ctrl-down)
 previous paragraph: key(ctrl-up)
 stop speech | be quiet: key(ctrl)
 
-# Date and time 
+# Date and time
 speak time | say time: user.with_jaws_mod_press("f12")
 speak date | say date: user.with_jaws_mod_press("f12, f12")
 
@@ -31,8 +31,10 @@ toggle speech | speech on demand: user.with_jaws_mod_layered_key_presses("space,
 quick settings: user.with_jaws_mod_press("v")
 increase speech rate | speak faster: key(ctrl-alt-super-pgup)
 decrease speech rate | speak slower: key(ctrl-alt-super-pgdown)
-increase jaws volume | jaws volume up | speak louder: user.with_jaws_mod_layered_key_presses("space, v, j, pgup, escape")
-decrease jaws volume | jaws volume down| speak softer: user.with_jaws_mod_layered_key_presses("space, v, j, pgdown, escape")
+increase jaws volume | jaws volume up | speak louder:
+    user.with_jaws_mod_layered_key_presses("space, v, j, pgup, escape")
+decrease jaws volume | jaws volume down | speak softer:
+    user.with_jaws_mod_layered_key_presses("space, v, j, pgdown, escape")
 
 # Navigating
 
@@ -49,7 +51,8 @@ headings list | list headings: user.with_jaws_mod_press("f6")
 forms list | list forms: user.with_jaws_mod_press("f5")
 
 # Reporting Location and Other Information
-speak text formatting | speak formatting | say text formatting | say formatting: user.with_jaws_mod_press("f")
+speak text formatting | speak formatting | say text formatting | say formatting:
+    user.with_jaws_mod_press("f")
 speak selection | say selection: user.with_jaws_mod_press("shift-a")
 speak link destination | say link destination: user.with_jaws_mod_press("k")
 speak window | say window | speak dialog | say dialog: user.with_jaws_mod_press("b")

--- a/jaws/jaws.talon
+++ b/jaws/jaws.talon
@@ -1,0 +1,103 @@
+tag: user.jaws_running
+os: windows
+-
+
+# Reader press <user.keys>: Use the JAWS modifier to press any key
+reader press <user.keys>: user.with_jaws_mod_press(keys)
+
+# Reading commands
+read below | start reading: user.with_jaws_mod_press("down")
+next word: key(ctrl-right)
+previous word: key(ctrl-left)
+speak line | say line: user.with_jaws_mod_press("up")
+next line: key(down)
+previous line: key(up)
+next paragraph: key(ctrl-down)
+previous paragraph: key(ctrl-up)
+stop speech | be quiet: key(ctrl)
+
+# Date and time 
+speak time | say time: user.with_jaws_mod_press("f12")
+speak date | say date: user.with_jaws_mod_press("f12, f12")
+
+# Toggle input help (JAWS help system for learning commands)
+toggle input help: user.with_jaws_mod_press("1")
+
+# JAWS settings (reader and synthesizer settings)
+open JAWS settings | JAWS settings center: user.with_jaws_mod_press("6")
+
+# Toggle speech (Toggle jaws sleep mode)
+toggle speech | speech on demand: user.with_jaws_mod_layered_key_presses("space, s")
+quick settings: user.with_jaws_mod_press("v")
+increase speech rate | speak faster: key(ctrl-alt-super-pgup)
+decrease speech rate | speak slower: key(ctrl-alt-super-pgdown)
+increase jaws volume | jaws volume up | speak louder: user.with_jaws_mod_layered_key_presses("space, v, j, pgup, escape")
+decrease jaws volume | jaws volume down| speak softer: user.with_jaws_mod_layered_key_presses("space, v, j, pgdown, escape")
+
+# Navigating
+
+#Window title
+speak title | say title: user.with_jaws_mod_press("t")
+
+# Move to search bar, address bar
+go to search | go search bar | go to search bar: key(ctrl-e)
+go to address bar | go address bar: key(alt-d)
+
+# Open element lists (JAWS-specific commands to list elements on the page)
+links list | list links: user.with_jaws_mod_press("f7")
+headings list | list headings: user.with_jaws_mod_press("f6")
+forms list | list forms: user.with_jaws_mod_press("f5")
+
+# Reporting Location and Other Information
+speak text formatting | speak formatting | say text formatting | say formatting: user.with_jaws_mod_press("f")
+speak selection | say selection: user.with_jaws_mod_press("shift-a")
+speak link destination | say link destination: user.with_jaws_mod_press("k")
+speak window | say window | speak dialog | say dialog: user.with_jaws_mod_press("b")
+speak focus | say focus | speak item | say item: user.with_jaws_mod_press("tab")
+
+# Navigation commands for table, list, graphic, link, and form elements
+next table: key(T)
+previous table: key(shift-T)
+next list: key(L)
+previous list: key(shift-L)
+next list item: key(I)
+previous list item: key(shift-I)
+next graphic: key(G)
+previous graphic: key(shift-G)
+next unvisited link: key(U)
+previous unvisited link: key(shift-U)
+next visited link: key(V)
+previous visited link: key(shift-V)
+Next form field: key(F)
+Previous form field: key(shift-F)
+Next edit box: key(E)
+Previous edit box: key(shift-E)
+Next combo box: key(C)
+Previous combo box: key(shift-C)
+Next tab: key(')
+Previous tab: key(shift-')
+Next button: key(B)
+previous button: key(shift-B)
+Next heading: key(H)
+previous heading: key(shift-h)
+next focusable item: key(tab)
+previous focusable item: key(shift-tab)
+next landmark | next region: key(r)
+previous landmark | previous region: key(shift-r)
+
+# Activate current element, press enter
+activate | activate that press enter | hit enter: key(enter)
+
+# Toggle selection for checkboxes, combo boxes, and radio buttons
+check that | uncheck that: key(space)
+open the box: key(alt-down)
+Next checkbox: key(X)
+previous checkbox: key(shift-X)
+Next radio button: key(A)
+Previous radio button: key(shift-A)
+
+# Pass through next command (used to send the next key press directly to the system)
+pass through next | pass through: user.with_jaws_mod_press("3")
+
+# Restart JAWS (restarts the JAWS application)
+restart reader | restart JAWS: user.restart_jaws()


### PR DESCRIPTION
Added support for using JAWS with Talon based on the NVDA package leveraging the JAWS COM API. There is currently no support for handling speech interrupts when dictating text. There should be a way to handle speech interrupts without using IPC due to the COM API calls available in JAWS though, but I am not familiar enough with JAWS scripting to figure this out.